### PR TITLE
US3114 Add a category to the list item

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ git clone git@github.com:boost/shopping-list.git
 cd shopping-list
 bundle install
 rake db:create
-rails db:migrate  
+rails db:migrate
+rails db:seed
 rails server
 ```
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -62,7 +62,7 @@ li {
   border-radius: 5px;
   color: white;
   margin: 0.5em auto;
-  max-width: 60%;
+  max-width: 80%;
   padding: 0.5em 1.5em;
 
   a {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def create
     @list = List.find(params[:list_id])
-    @item = @list.items.create(comment_params)
+    @item = @list.items.create(item_params)
 
     flash[:notice] = @item.errors.full_messages if @item.errors.count > 0
 
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
 
   private
 
-  def comment_params
-    params.require(:item).permit(:name, :quantity)
+  def item_params
+    params.require(:item).permit(:name, :quantity, :category_id)
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -5,6 +5,7 @@ class ListsController < ApplicationController
 
   def show
     @list = List.find(params[:id])
+    @categories = Category.all
   end
 
   def new

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,9 +1,13 @@
 module ItemsHelper
-  def item_class(item)
+  def list_item_class(item)
     if item.checked
       'item-data checked'
     else
       'item-data'
     end
+  end
+
+  def category_name(item)
+    item.category ? item.category.name : 'unknown'
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :list
+  belongs_to :category
   validates :name, presence: true, length: { minimum: 3 }
   validates :quantity, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :category_id, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -5,6 +5,7 @@
     <ul>
       <% @list.items.each do |item| %>
         <li>
+          <span><%= item.category ? item.category.name : "unknown" %></span>
           <%= link_to list_item_toggle_checked_path(@list.id, item.id), method: :put, class: item_class(item) do %>
             <span><%= item.name %></span>
             <span><%= item.quantity %></span>
@@ -39,6 +40,7 @@
     <%= form.text_field :name, placeholder: :name %>
     <%= form.label :quantity %>
     <%= form.number_field :quantity, value: 1 %>
+    <%= form.select(:category_id, options_for_select(@categories.map { |c| [c.name, c.id] })) %>
     <%= form.submit "Add item" %>
   </p>
 <% end %>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -5,8 +5,8 @@
     <ul>
       <% @list.items.each do |item| %>
         <li>
-          <span><%= item.category ? item.category.name : "unknown" %></span>
-          <%= link_to list_item_toggle_checked_path(@list.id, item.id), method: :put, class: item_class(item) do %>
+          <span><%= category_name(item) %></span>
+          <%= link_to list_item_toggle_checked_path(@list.id, item.id), method: :put, class: list_item_class(item) do %>
             <span><%= item.name %></span>
             <span><%= item.quantity %></span>
           <% end %>

--- a/db/migrate/20180912023230_create_categories.rb
+++ b/db/migrate/20180912023230_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180912031138_change_field_name.rb
+++ b/db/migrate/20180912031138_change_field_name.rb
@@ -1,0 +1,9 @@
+class ChangeFieldName < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :items, :category, :category_id
+  end
+
+  def down
+    rename_column :items, :category_id, :category
+  end
+end

--- a/db/migrate/20180912032307_category_id_to_bigint.rb
+++ b/db/migrate/20180912032307_category_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class CategoryIdToBigint < ActiveRecord::Migration[5.2]
+  def change
+    change_column :items, :category_id, :bigint
+  end
+end

--- a/db/migrate/20180912032450_link_category_and_item.rb
+++ b/db/migrate/20180912032450_link_category_and_item.rb
@@ -1,0 +1,5 @@
+class LinkCategoryAndItem < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :items, :categories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_12_002244) do
+ActiveRecord::Schema.define(version: 2018_09_12_032450) do
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.integer "quantity", null: false
-    t.integer "category"
+    t.bigint "category_id"
     t.boolean "checked", default: false, null: false
     t.bigint "list_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "fk_rails_89fb86dc8b"
     t.index ["list_id"], name: "index_items_on_list_id"
   end
 
@@ -28,5 +35,6 @@ ActiveRecord::Schema.define(version: 2018_09_12_002244) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "items", "categories"
   add_foreign_key "items", "lists"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,35 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+item_categories = [
+  'Fruit and Veg',
+  'Butchery',
+  'Dairy & Eggs',
+  'Wine',
+  'Beer and Cider',
+  'Bakery',
+  'Baking Supplies',
+  'Sanitary',
+  'Breakfast Cereals',
+  'Canned Foods',
+  'Cleaning Products',
+  'Cold Drinks',
+  'Condiments',
+  'Confectionary',
+  'Deli',
+  'Desserts',
+  'Frozen Foods',
+  'Health',
+  'Hot Drinks',
+  'Household',
+  'Jams, Honey and Spreads',
+  'Laundry',
+  'Snack Foods',
+  'Stationary',
+  'Misc'
+]
+
+item_categories.each do |category|
+  Category.create(name: category)
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The list page now includes an HTML `<select>` including all of the possible categories.

The categories are stored in the categories DB table, which is linked to the items table on the `category_id` field.
The categories DB table is populated from the seed file.

I set this up using several migrations:
• Creating the Categories DB table
• Changing `item.category` → `item.category_id`
• Changing `item.category_id` to a type of `bigint` (to match the primary key for the category table)
• Linking Items and Categories via a foreign key

It may have been possible to combine some of these migrations? I took a cautious approach.

Plus I added a `belongs_to` relation and `validation` on the Items model.

The categories are displayed in the list:
<img width="470" alt="shopping-list_category" src="https://user-images.githubusercontent.com/43123718/45401131-52cea900-b6a3-11e8-9b3e-79a8ad1b390a.png">