### PR TITLE
CLEANING UP DEFAULT SHOPPING LIST

### DIFF
--- a/app/services/yum/create_order.rb
+++ b/app/services/yum/create_order.rb
@@ -31,7 +31,7 @@ module Yum
                ShoppingList.where(primary: true)
              end
 
-      (list.presence || ShoppingList.where(name: 'default list')).first
+      list.presence || ShoppingList.first
     end
 
     def message_for(order)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,6 @@ item_categories.each do |category|
   Category.create(name: category)
 end
 
-ShoppingList.create(name: 'Default list', primary: true)
-ShoppingList.create(name: 'lunch')
+ShoppingList.create(name: 'lunch', primary: true)
 ShoppingList.create(name: 'grocery')
+ShoppingList.create(name: 'books')


### PR DESCRIPTION
Why  : A shopping list's name shouldnt be a condition to create an order
What : Removing default shopping list condition from get_shopping_list
       Updated the seed