### PR TITLE
Remove Category: model, DB table, all uses

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -50,6 +50,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :quantity, :category_id)
+    params.require(:item).permit(:name, :quantity)
   end
 end

--- a/app/controllers/shopping_lists_controller.rb
+++ b/app/controllers/shopping_lists_controller.rb
@@ -9,7 +9,6 @@ class ShoppingListsController < ApplicationController
 
   def show
     @shopping_list = ShoppingList.find(params[:id])
-    @categories = Category.all
   end
 
   def new

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -6,8 +6,4 @@ module ItemsHelper
 
     'row' + checked
   end
-
-  def category_name(item)
-    item.category ? item.category.name : 'unknown'
-  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-class Category < ApplicationRecord; end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,8 +2,6 @@
 
 class Item < ApplicationRecord
   belongs_to :shopping_list
-  belongs_to :category
   validates :name, presence: true, length: { minimum: 3 }
   validates :quantity, presence: true, numericality: { greater_than_or_equal_to: 0 }
-  validates :category_id, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/services/yum/create_order.rb
+++ b/app/services/yum/create_order.rb
@@ -16,8 +16,7 @@ module Yum
       order = @shopping_list.items.create(name: @name,
                                           quantity: @quantity,
                                           ordered_by: @ordered_by,
-                                          ordered_for: @ordered_for,
-                                          category_id: 25) # Hardcoding the 'Misc' category ID for the moment
+                                          ordered_for: @ordered_for)
 
       message = order ? message_for(order) : 'Something went wrong. Throw something soft at Eddie'
 

--- a/app/views/shopping_lists/_shopping_list_item.html.erb
+++ b/app/views/shopping_lists/_shopping_list_item.html.erb
@@ -2,7 +2,7 @@
   <%= link_to shopping_list_item_toggle_checked_path(@shopping_list.id, item.id), method: :put, class: 'column small-6 large-4' do %>
     <div class="item-name"><%= item.name %></div>
   <% end %>
-  <div class="column small-6 large-3">
+  <div class="column small-4 large-3">
     <%= link_to shopping_list_item_decrement_quantity_path(@shopping_list.id, item.id), method: :put, class: "decrement-quantity" do %>
       <i class="icon-left fi-minus"></i>
     <% end %>
@@ -11,10 +11,10 @@
       <i class="icon-right fi-plus"></i>
     <% end %>
   </div>
-  <%= link_to [item.shopping_list, item], method: :delete, class: 'delete-item column small-3 large-1' do %>
+  <%= link_to [item.shopping_list, item], method: :delete, class: 'delete-item column small-2 large-1' do %>
     <i class="fi-trash"></i>
   <% end %>
-  <div class="column small-9 large-4">
+  <div class="column small-12 large-4">
     <% if item.ordered_by && item.ordered_for %>
       by: <%= item.ordered_by %>, for: <%= item.ordered_for %>
     <% end %>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -25,16 +25,13 @@
 
 <%= form_with(model: [ @shopping_list, @shopping_list.items.build ], local: true) do |form| %>
   <div class="row">
-    <div class="columns small-9 large-4">
+    <div class="columns small-6">
       <%= form.text_field :name, placeholder: :name %>
     </div>
-    <div class="columns small-3 large-2">
+    <div class="columns small-2">
       <%= form.number_field :quantity, value: 1 %>
     </div>
-    <div class="columns small-6 large-3">
-      <%= form.select(:category_id, options_for_select(@categories.map { |c| [c.name, c.id] })) %>
-    </div>
-    <div class="columns small-6 large-3">
+    <div class="columns small-4">
       <%= form.submit 'Add item', class: 'button small' %>
     </div>
   </div>

--- a/db/migrate/20180912023230_create_categories.rb
+++ b/db/migrate/20180912023230_create_categories.rb
@@ -1,9 +1,0 @@
-class CreateCategories < ActiveRecord::Migration[5.2]
-  def change
-    create_table :categories do |t|
-      t.string :name
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20181019031047_remove_category_from_items.rb
+++ b/db/migrate/20181019031047_remove_category_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveCategoryFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :category_id, :bigint
+  end
+end

--- a/db/migrate/20181019031312_drop_category_table.rb
+++ b/db/migrate/20181019031312_drop_category_table.rb
@@ -1,0 +1,8 @@
+class DropCategoryTable < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :categories do |t|
+      t.string "name"
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_04_220734) do
-
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
+ActiveRecord::Schema.define(version: 2018_10_19_031312) do
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.integer "quantity", default: 1, null: false
-    t.bigint "category_id"
     t.boolean "checked", default: false, null: false
     t.bigint "shopping_list_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ordered_by"
     t.string "ordered_for"
-    t.index ["category_id"], name: "fk_rails_89fb86dc8b"
     t.index ["shopping_list_id"], name: "index_items_on_shopping_list_id"
   end
 
@@ -39,6 +31,5 @@ ActiveRecord::Schema.define(version: 2018_10_04_220734) do
     t.boolean "primary", default: false
   end
 
-  add_foreign_key "items", "categories"
   add_foreign_key "items", "shopping_lists"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,38 +6,6 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-item_categories = [
-  'Fruit and Veg',
-  'Butchery',
-  'Dairy & Eggs',
-  'Wine',
-  'Beer and Cider',
-  'Bakery',
-  'Baking Supplies',
-  'Sanitary',
-  'Breakfast Cereals',
-  'Canned Foods',
-  'Cleaning Products',
-  'Cold Drinks',
-  'Condiments',
-  'Confectionary',
-  'Deli',
-  'Desserts',
-  'Frozen Foods',
-  'Health',
-  'Hot Drinks',
-  'Household',
-  'Jams, Honey and Spreads',
-  'Laundry',
-  'Snack Foods',
-  'Stationary',
-  'Misc'
-]
-
-item_categories.each do |category|
-  Category.create(name: category)
-end
-
 ShoppingList.create(name: 'lunch', primary: true)
 ShoppingList.create(name: 'grocery')
 ShoppingList.create(name: 'books')

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :category do
-    name { 'Fruit & veg' }
-  end
-end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
     quantity { 2 }
 
     association :shopping_list
-    association :category
   end
 end


### PR DESCRIPTION
I've talked to Natalie, and she says that having a category for each item is not useful to her. (Also, the categories relate to supermarket items, but aren't relevant for lunches, Office Max list, etc).

So this PR removes the `Category` model and all of its uses, as well as removing the DB table.